### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-freshbooks/main.go
+++ b/cmd/baton-freshbooks/main.go
@@ -48,9 +48,9 @@ func getConnector(ctx context.Context, fbc *cfg.Freshbooks) (types.ConnectorServ
 	var connectorOpts []connector.Option
 
 	if fbc.AccessToken != "" {
-		connectorOpts = append(connectorOpts, connector.WithAccessToken(ctx, fbc.AccessToken))
+		connectorOpts = append(connectorOpts, connector.WithAccessToken(ctx, fbc.AccessToken, fbc.BaseUrl))
 	} else if fbc.RefreshToken != "" && fbc.FreshbooksClientId != "" && fbc.FreshbooksClientSecret != "" {
-		connectorOpts = append(connectorOpts, connector.WithRefreshToken(ctx, fbc.RefreshToken, fbc.FreshbooksClientId, fbc.FreshbooksClientSecret))
+		connectorOpts = append(connectorOpts, connector.WithRefreshToken(ctx, fbc.RefreshToken, fbc.FreshbooksClientId, fbc.FreshbooksClientSecret, fbc.BaseUrl))
 	}
 
 	if len(connectorOpts) == 0 {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	DefaultBaseURL  = "https://api.freshbooks.com/auth"
-	getNewToken     = "/oauth/token" // #nosec G101
-	getBusinessID   = "/api/v1/users/me"
+	DefaultBaseURL = "https://api.freshbooks.com/auth"
+	getNewToken    = "/oauth/token" // #nosec G101
+	getBusinessID  = "/api/v1/users/me"
 
 	businessBaseURL = "/api/v1/businesses/"
 	getTeamMembers  = "/team_members"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	baseURL       = "https://api.freshbooks.com/auth"
-	getNewToken   = "/oauth/token" // #nosec G101
-	getBusinessID = "/api/v1/users/me"
+	DefaultBaseURL  = "https://api.freshbooks.com/auth"
+	getNewToken     = "/oauth/token" // #nosec G101
+	getBusinessID   = "/api/v1/users/me"
 
 	businessBaseURL = "/api/v1/businesses/"
 	getTeamMembers  = "/team_members"
@@ -30,6 +30,7 @@ type FreshBooksClient struct {
 	client      *uhttp.BaseHttpClient
 	TokenSource oauth2.TokenSource
 	Config      Config
+	baseURL     string
 }
 
 type Config struct {
@@ -42,6 +43,12 @@ type Option func(client *FreshBooksClient)
 func WithBearerToken(apiToken string) Option {
 	return func(client *FreshBooksClient) {
 		client.SetToken(apiToken)
+	}
+}
+
+func WithBaseURL(baseURL string) Option {
+	return func(client *FreshBooksClient) {
+		client.baseURL = baseURL
 	}
 }
 
@@ -59,7 +66,7 @@ func WithRefreshToken(ctx context.Context, refreshToken, clientID, clientSecret 
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			Endpoint: oauth2.Endpoint{
-				TokenURL: baseURL + getNewToken,
+				TokenURL: client.baseURL + getNewToken,
 			},
 		}
 		tokenSource := oauth2.ReuseTokenSource(token, config.TokenSource(ctx, token))
@@ -111,7 +118,8 @@ func New(ctx context.Context, opts ...Option) (*FreshBooksClient, error) {
 	}
 
 	fbClient := FreshBooksClient{
-		client: cli,
+		client:  cli,
+		baseURL: DefaultBaseURL,
 	}
 
 	for _, o := range opts {
@@ -139,7 +147,7 @@ func (f *FreshBooksClient) getListFromAPI(
 
 // ListTeamMembers Gets all the Team Members from FreshBooks and deserialized them into an Array.
 func (f *FreshBooksClient) ListTeamMembers(ctx context.Context, opts PageOptions) ([]TeamMember, string, annotations.Annotations, error) {
-	queryUrl, err := url.JoinPath(baseURL, businessBaseURL, f.BusinessID(), getTeamMembers)
+	queryUrl, err := url.JoinPath(f.baseURL, businessBaseURL, f.BusinessID(), getTeamMembers)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -161,7 +169,7 @@ func (f *FreshBooksClient) ListTeamMembers(ctx context.Context, opts PageOptions
 
 func (f *FreshBooksClient) RequestBusinessID(ctx context.Context) (int64, error) {
 	var response ResponseBID
-	queryUrl, err := url.JoinPath(baseURL, getBusinessID)
+	queryUrl, err := url.JoinPath(f.baseURL, getBusinessID)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -66,7 +67,7 @@ func WithRefreshToken(ctx context.Context, refreshToken, clientID, clientSecret 
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			Endpoint: oauth2.Endpoint{
-				TokenURL: client.baseURL + getNewToken,
+				TokenURL: strings.TrimRight(client.baseURL, "/") + getNewToken,
 			},
 		}
 		tokenSource := oauth2.ReuseTokenSource(token, config.TokenSource(ctx, token))

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Freshbooks struct {
 	RefreshToken string `mapstructure:"refresh-token"`
 	FreshbooksClientId string `mapstructure:"freshbooks-client-id"`
 	FreshbooksClientSecret string `mapstructure:"freshbooks-client-secret"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c* Freshbooks) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ const (
 	refreshToken   = "refresh-token"
 	fbClientID     = "freshbooks-client-id"
 	fbClientSecret = "freshbooks-client-secret"
+	baseURL        = "base-url"
 )
 
 var (
@@ -33,7 +34,11 @@ var (
 		field.WithDisplayName("Client Secret"),
 		field.WithDescription("Client Secret from the Freshbooks app"))
 
-	configFields = []field.SchemaField{TokenField, RefreshTokenField, ClientIDField, ClientSecretField}
+	BaseURLField = field.StringField(
+		baseURL,
+		field.WithDescription("Override the FreshBooks API URL (for testing)"))
+
+	configFields = []field.SchemaField{TokenField, RefreshTokenField, ClientIDField, ClientSecretField, BaseURLField}
 
 	fieldRelationships = []field.SchemaFieldRelationship{
 		field.FieldsAtLeastOneUsed(TokenField, RefreshTokenField),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,7 +36,8 @@ var (
 
 	BaseURLField = field.StringField(
 		baseURL,
-		field.WithDescription("Override the FreshBooks API URL (for testing)"))
+		field.WithDescription("Override the FreshBooks API URL (for testing)"),
+		field.WithHidden(true))
 
 	configFields = []field.SchemaField{TokenField, RefreshTokenField, ClientIDField, ClientSecretField, BaseURLField}
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -28,12 +28,11 @@ func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.Resour
 
 func WithRefreshToken(ctx context.Context, refreshToken, clientID, clientSecret, baseURL string) Option {
 	return func(c *Connector) error {
-		clientOpts := []client.Option{
-			client.WithRefreshToken(ctx, refreshToken, clientID, clientSecret),
-		}
+		var clientOpts []client.Option
 		if baseURL != "" {
 			clientOpts = append(clientOpts, client.WithBaseURL(baseURL))
 		}
+		clientOpts = append(clientOpts, client.WithRefreshToken(ctx, refreshToken, clientID, clientSecret))
 		fbc, err := client.New(ctx, clientOpts...)
 		if err != nil {
 			return fmt.Errorf("error applying option WithRefreshToken: %w", err)

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -26,10 +26,13 @@ func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.Resour
 	}
 }
 
-func WithRefreshToken(ctx context.Context, refreshToken, clientID, clientSecret string) Option {
+func WithRefreshToken(ctx context.Context, refreshToken, clientID, clientSecret, baseURL string) Option {
 	return func(c *Connector) error {
 		clientOpts := []client.Option{
 			client.WithRefreshToken(ctx, refreshToken, clientID, clientSecret),
+		}
+		if baseURL != "" {
+			clientOpts = append(clientOpts, client.WithBaseURL(baseURL))
 		}
 		fbc, err := client.New(ctx, clientOpts...)
 		if err != nil {
@@ -41,9 +44,15 @@ func WithRefreshToken(ctx context.Context, refreshToken, clientID, clientSecret 
 	}
 }
 
-func WithAccessToken(ctx context.Context, accessToken string) Option {
+func WithAccessToken(ctx context.Context, accessToken, baseURL string) Option {
 	return func(c *Connector) error {
-		fbc, err := client.New(ctx, client.WithBearerToken(accessToken))
+		clientOpts := []client.Option{
+			client.WithBearerToken(accessToken),
+		}
+		if baseURL != "" {
+			clientOpts = append(clientOpts, client.WithBaseURL(baseURL))
+		}
+		fbc, err := client.New(ctx, clientOpts...)
 		if err != nil {
 			return fmt.Errorf("error applying option WithAccessToken: %w", err)
 		}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-freshbooks/main.go,pkg/client/client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-freshbooks --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable FreshBooks API base URL so endpoints can be customized for testing or alternative environments.

* **Configuration**
  * New configuration field and CLI/config option to override the FreshBooks base URL.

* **Integration**
  * Connection/setup options updated to accept an optional custom base URL when creating clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->