### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a FreshBooks connector"
 og:title: "Set up a FreshBooks connector"
-description: "C1 provides identity governance and just-in-time provisioning for FreshBooks. Integrate your FreshBooks instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "C1 provides identity governance and just-in-time provisioning for FreshBooks. Integrate your FreshBooks instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance for FreshBooks. Integrate your FreshBooks instance with C1 for unified visibility and governance over user access."
+og:description: "C1 provides identity governance for FreshBooks. Integrate your FreshBooks instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "FreshBooks"
 ---
 
@@ -86,7 +86,7 @@ The response will look like this:
 Carefully copy and save the **refresh token**. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the FreshBooks connector
 
@@ -142,7 +142,7 @@ Click **Login with OAuth** and follow the prompts.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your FreshBooks connector is now pulling access data into C1.
+**Done.** Your FreshBooks connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -256,7 +256,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the FreshBooks connector to. FreshBooks data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your FreshBooks connector is now pulling access data into C1.
+**Done.** Your FreshBooks connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines