### PR TITLE
fix: mark access-token, refresh-token and freshbooks-client-secret as isSecret in config_schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,11 +18,12 @@ var (
 		token, field.WithRequired(false),
 		field.WithDisplayName("Access Token"),
 		field.WithDescription("Token to request data from the FreshBooks APIs"),
+		field.WithIsSecret(true),
 	)
 	RefreshTokenField = field.StringField(
 		refreshToken, field.WithRequired(false),
 		field.WithDisplayName("Refresh Token"),
-		field.WithDescription("Refresh token used to get a new access token from FreshBooks"))
+		field.WithDescription("Refresh token used to get a new access token from FreshBooks"), field.WithIsSecret(true))
 
 	ClientIDField = field.StringField(
 		fbClientID, field.WithRequired(false),
@@ -32,7 +33,7 @@ var (
 	ClientSecretField = field.StringField(
 		fbClientSecret, field.WithRequired(false),
 		field.WithDisplayName("Client Secret"),
-		field.WithDescription("Client Secret from the Freshbooks app"))
+		field.WithDescription("Client Secret from the Freshbooks app"), field.WithIsSecret(true))
 
 	BaseURLField = field.StringField(
 		baseURL,


### PR DESCRIPTION
The `access-token`, `refresh-token`, and `freshbooks-client-secret` fields are OAuth credentials but were plain `field.StringField` with no `field.WithIsSecret(true)`, so none was marked secret. This adds `WithIsSecret(true)` to all three. `freshbooks-client-id` is a public client identifier and `base-url` is a test override; both are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

_Built with stargate._
