### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -75,11 +75,9 @@ func parseIntoRoleResource(role client.Role, _ *v2.ResourceId) (*v2.Resource, er
 		"name": role.RoleName,
 	}
 
-	roleTraits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraits := []rs.RoleTraitOption{}
 
-	ret, err := rs.NewRoleResource(role.RoleName, roleResourceType, role.BusinessRoleName, roleTraits)
+	ret, err := rs.NewRoleResource(role.RoleName, roleResourceType, role.BusinessRoleName, roleTraits, rs.WithResourceProfile(profile))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -75,7 +75,7 @@ func (u *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncO
 // business_role_name stored on the user's profile during List, so no
 // additional API call (nor a cached team-member list) is needed here.
 func (u *userBuilder) Grants(_ context.Context, user *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	businessRoleName, ok := rs.GetProfileStringValue(user.GetProfile(), "business_role_name")
+	businessRoleName, ok := rs.GetProfileStringValue(rs.GetProfile(user), "business_role_name")
 	if !ok || businessRoleName == "" {
 		// User has no role assignment.
 		return nil, nil, nil

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -75,12 +75,7 @@ func (u *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncO
 // business_role_name stored on the user's profile during List, so no
 // additional API call (nor a cached team-member list) is needed here.
 func (u *userBuilder) Grants(_ context.Context, user *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	userTrait, err := rs.GetUserTrait(user)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	businessRoleName, ok := rs.GetProfileStringValue(userTrait.GetProfile(), "business_role_name")
+	businessRoleName, ok := rs.GetProfileStringValue(user.GetProfile(), "business_role_name")
 	if !ok || businessRoleName == "" {
 		// User has no role assignment.
 		return nil, nil, nil
@@ -121,8 +116,6 @@ func parseIntoUserResource(teamMember client.TeamMember, parentResourceID *v2.Re
 	}
 
 	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(userStatus),
 		rs.WithUserLogin(teamMember.Email),
 		rs.WithEmail(teamMember.Email, true),
 	}
@@ -137,6 +130,8 @@ func parseIntoUserResource(teamMember client.TeamMember, parentResourceID *v2.Re
 		userResourceType,
 		teamMember.UUID,
 		userTraits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
