### PR TITLE
Guard role grant emission behind WillSyncResourceType

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -20,6 +20,11 @@
         "displayName": "User",
         "traits": [
           "TRAIT_USER"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
+          }
         ]
       },
       "capabilities": [

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -13,6 +13,10 @@ sidebarTitle: "FreshBooks"
 | Users | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
 
+<Note>
+**User entitlements.** Users carry no entitlements of their own — a user's role assignment is expressed as a grant against Roles. When Roles are excluded from the sync, the connector skips the user grant pass as well, since the roles those grants point at wouldn't be present.
+</Note>
+
 ## Gather FreshBooks credentials 
 
 Configuring the connector requires you to pass in credentials generated in FreshBooks. Gather these credentials before you move on. 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,6 +18,18 @@ import (
 
 type Connector struct {
 	client *client.FreshBooksClient
+	// skipRoleResourceType reports whether role is excluded from the sync
+	// filter. Named for the skip condition so the zero value is safe: main.go
+	// registers a zero-value Connector{} as the capabilities factory.
+	skipRoleResourceType bool
+}
+
+// WithSkipRoleResourceType records that role is excluded from this sync.
+func WithSkipRoleResourceType(skip bool) Option {
+	return func(c *Connector) error {
+		c.skipRoleResourceType = skip
+		return nil
+	}
 }
 
 type Option func(*Connector) error
@@ -25,7 +37,7 @@ type Option func(*Connector) error
 // ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(_ context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client),
+		newUserBuilder(d.client, d.skipRoleResourceType),
 		newRoleBuilder(d.client),
 	}
 }
@@ -130,6 +142,10 @@ func NewLambdaConnector(ctx context.Context, fbc *cfg.Freshbooks, cliOpts *cli.C
 	if len(connectorOpts) == 0 {
 		return nil, nil, fmt.Errorf("[token] or [refresh-token, fb-client-id, fb-client-secret] argumetns must provided")
 	}
+
+	// nil cliOpts means no filter, so nothing is skipped.
+	connectorOpts = append(connectorOpts,
+		WithSkipRoleResourceType(cliOpts != nil && !cliOpts.WillSyncResourceType(RoleResourceTypeID)))
 
 	c, err := New(ctx, connectorOpts...)
 	if err != nil {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -126,7 +126,11 @@ func New(_ context.Context, opts ...Option) (*Connector, error) {
 func NewLambdaConnector(ctx context.Context, fbc *cfg.Freshbooks, cliOpts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	var connectorOpts []Option
 
-	tokenSource := cliOpts.TokenSource
+	// nil cliOpts means no SDK-supplied token source and no sync filter.
+	var tokenSource oauth2.TokenSource
+	if cliOpts != nil {
+		tokenSource = cliOpts.TokenSource
+	}
 
 	switch {
 	case tokenSource != nil:
@@ -143,7 +147,7 @@ func NewLambdaConnector(ctx context.Context, fbc *cfg.Freshbooks, cliOpts *cli.C
 		return nil, nil, fmt.Errorf("[token] or [refresh-token, fb-client-id, fb-client-secret] argumetns must provided")
 	}
 
-	// nil cliOpts means no filter, so nothing is skipped.
+	// nil cliOpts means no filter, so nothing is skipped (see above).
 	connectorOpts = append(connectorOpts,
 		WithSkipRoleResourceType(cliOpts != nil && !cliOpts.WillSyncResourceType(RoleResourceTypeID)))
 

--- a/pkg/connector/integration_test.go
+++ b/pkg/connector/integration_test.go
@@ -39,7 +39,7 @@ func TestUserBuilderListWithAcessToken(t *testing.T) {
 		message = fmt.Sprintf("error creating client: %v", err)
 		t.Fatal(message)
 	}
-	u := newUserBuilder(c)
+	u := newUserBuilder(c, false)
 
 	users, _, err := u.List(ctx, parentResourceID, syncOpAttrs)
 	assert.Nil(t, err)

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -4,14 +4,19 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 )
 
+// newUserBuilder clones this and adds SkipEntitlements, or
+// SkipEntitlementsAndGrants when role isn't synced.
 var userResourceType = &v2.ResourceType{
 	Id:          "user",
 	DisplayName: "User",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
 }
 
+// RoleResourceTypeID is referenced when gating cross-type role grants.
+const RoleResourceTypeID = "role"
+
 var roleResourceType = &v2.ResourceType{
-	Id:          "role",
+	Id:          RoleResourceTypeID,
 	DisplayName: "Role",
 	Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_ROLE},
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/conductorone/baton-freshbooks/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"google.golang.org/protobuf/proto"
 )
 
 type userBuilder struct {
@@ -15,7 +17,7 @@ type userBuilder struct {
 }
 
 func (u *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
-	return userResourceType
+	return u.resourceType
 }
 
 // List returns all the users from the database as resource objects.
@@ -94,9 +96,21 @@ func (u *userBuilder) Grants(_ context.Context, user *v2.Resource, _ rs.SyncOpAt
 	return []*v2.Grant{roleGrant}, nil, nil
 }
 
-func newUserBuilder(client *client.FreshBooksClient) *userBuilder {
+// newUserBuilder returns the user syncer. Users have no entitlements of their
+// own, and their only grants are cross-type role grants, so when role is
+// excluded from the sync the grants pass is skipped too.
+func newUserBuilder(client *client.FreshBooksClient, skipRoleResourceType bool) *userBuilder {
+	rt := proto.Clone(userResourceType).(*v2.ResourceType)
+	annos := annotations.Annotations(rt.GetAnnotations())
+	if skipRoleResourceType {
+		annos.Update(&v2.SkipEntitlementsAndGrants{})
+	} else {
+		annos.Update(&v2.SkipEntitlements{})
+	}
+	rt.Annotations = annos
+
 	return &userBuilder{
-		resourceType: userResourceType,
+		resourceType: rt,
 		client:       client,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -14,6 +14,10 @@ import (
 type userBuilder struct {
 	resourceType *v2.ResourceType
 	client       *client.FreshBooksClient
+	// skipRoleResourceType reports whether role is excluded from the sync, so
+	// Grants can suppress role grants on its own rather than relying solely on
+	// the SkipEntitlementsAndGrants annotation.
+	skipRoleResourceType bool
 }
 
 func (u *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -77,6 +81,11 @@ func (u *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncO
 // business_role_name stored on the user's profile during List, so no
 // additional API call (nor a cached team-member list) is needed here.
 func (u *userBuilder) Grants(_ context.Context, user *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	if u.skipRoleResourceType {
+		// Role is excluded from the sync, so a role grant would dangle.
+		return nil, nil, nil
+	}
+
 	businessRoleName, ok := rs.GetProfileStringValue(rs.GetProfile(user), "business_role_name")
 	if !ok || businessRoleName == "" {
 		// User has no role assignment.
@@ -110,8 +119,9 @@ func newUserBuilder(client *client.FreshBooksClient, skipRoleResourceType bool) 
 	rt.Annotations = annos
 
 	return &userBuilder{
-		resourceType: rt,
-		client:       client,
+		resourceType:         rt,
+		client:               client,
+		skipRoleResourceType: skipRoleResourceType,
 	}
 }
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -14,10 +14,6 @@ import (
 type userBuilder struct {
 	resourceType *v2.ResourceType
 	client       *client.FreshBooksClient
-	// skipRoleResourceType reports whether role is excluded from the sync, so
-	// Grants can suppress role grants on its own rather than relying solely on
-	// the SkipEntitlementsAndGrants annotation.
-	skipRoleResourceType bool
 }
 
 func (u *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -81,11 +77,6 @@ func (u *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncO
 // business_role_name stored on the user's profile during List, so no
 // additional API call (nor a cached team-member list) is needed here.
 func (u *userBuilder) Grants(_ context.Context, user *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	if u.skipRoleResourceType {
-		// Role is excluded from the sync, so a role grant would dangle.
-		return nil, nil, nil
-	}
-
 	businessRoleName, ok := rs.GetProfileStringValue(rs.GetProfile(user), "business_role_name")
 	if !ok || businessRoleName == "" {
 		// User has no role assignment.
@@ -119,9 +110,8 @@ func newUserBuilder(client *client.FreshBooksClient, skipRoleResourceType bool) 
 	rt.Annotations = annos
 
 	return &userBuilder{
-		resourceType:         rt,
-		client:               client,
-		skipRoleResourceType: skipRoleResourceType,
+		resourceType: rt,
+		client:       client,
 	}
 }
 

--- a/pkg/connector/users_guard_test.go
+++ b/pkg/connector/users_guard_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/conductorone/baton-freshbooks/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -30,21 +32,57 @@ func TestUserResourceType_SkipAnnotation(t *testing.T) {
 		t.Fatalf("role filtered: want SkipEntitlementsAndGrants, got %v", filtered.Annotations)
 	}
 
-	if hasAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) {
+	// Both branches annotate, so check for either leaking onto the shared
+	// package-level value if the proto.Clone is ever dropped.
+	if hasAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) || hasAnno(userResourceType, &v2.SkipEntitlements{}) {
 		t.Fatal("package-level userResourceType was mutated")
+	}
+}
+
+// Grants suppresses the role grant itself when role is filtered out, rather
+// than relying only on the SkipEntitlementsAndGrants annotation.
+func TestUserGrants_SkipsRoleGrantWhenFiltered(t *testing.T) {
+	user, err := parseIntoUserResource(client.TeamMember{
+		UUID:             "1",
+		Email:            "user@example.com",
+		BusinessRoleName: "owner",
+	}, nil)
+	if err != nil {
+		t.Fatalf("parseIntoUserResource: %v", err)
+	}
+
+	inScope, _, err := newUserBuilder(nil, false).Grants(context.Background(), user, rs.SyncOpAttrs{})
+	if err != nil {
+		t.Fatalf("role in scope: %v", err)
+	}
+	if len(inScope) != 1 {
+		t.Fatalf("role in scope: want 1 grant, got %d", len(inScope))
+	}
+
+	filtered, _, err := newUserBuilder(nil, true).Grants(context.Background(), user, rs.SyncOpAttrs{})
+	if err != nil {
+		t.Fatalf("role filtered: %v", err)
+	}
+	if len(filtered) != 0 {
+		t.Fatalf("role filtered: want 0 grants, got %d", len(filtered))
 	}
 }
 
 // main.go registers a zero-value Connector{} as the capabilities factory, which
 // bypasses New; it must report the unfiltered capability set.
 func TestZeroValueConnector_DoesNotSkipGrants(t *testing.T) {
+	var found bool
 	for _, s := range (&Connector{}).ResourceSyncers(context.Background()) {
 		rt := s.ResourceType(context.Background())
 		if rt.GetId() != userResourceType.Id {
 			continue
 		}
+		found = true
 		if hasAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
 			t.Fatal("zero-value Connector advertised SkipEntitlementsAndGrants")
 		}
+	}
+	if !found {
+		t.Fatalf("user syncer missing from ResourceSyncers; nothing was asserted")
 	}
 }

--- a/pkg/connector/users_guard_test.go
+++ b/pkg/connector/users_guard_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conductorone/baton-freshbooks/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -36,35 +34,6 @@ func TestUserResourceType_SkipAnnotation(t *testing.T) {
 	// package-level value if the proto.Clone is ever dropped.
 	if hasAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) || hasAnno(userResourceType, &v2.SkipEntitlements{}) {
 		t.Fatal("package-level userResourceType was mutated")
-	}
-}
-
-// Grants suppresses the role grant itself when role is filtered out, rather
-// than relying only on the SkipEntitlementsAndGrants annotation.
-func TestUserGrants_SkipsRoleGrantWhenFiltered(t *testing.T) {
-	user, err := parseIntoUserResource(client.TeamMember{
-		UUID:             "1",
-		Email:            "user@example.com",
-		BusinessRoleName: "owner",
-	}, nil)
-	if err != nil {
-		t.Fatalf("parseIntoUserResource: %v", err)
-	}
-
-	inScope, _, err := newUserBuilder(nil, false).Grants(context.Background(), user, rs.SyncOpAttrs{})
-	if err != nil {
-		t.Fatalf("role in scope: %v", err)
-	}
-	if len(inScope) != 1 {
-		t.Fatalf("role in scope: want 1 grant, got %d", len(inScope))
-	}
-
-	filtered, _, err := newUserBuilder(nil, true).Grants(context.Background(), user, rs.SyncOpAttrs{})
-	if err != nil {
-		t.Fatalf("role filtered: %v", err)
-	}
-	if len(filtered) != 0 {
-		t.Fatalf("role filtered: want 0 grants, got %d", len(filtered))
 	}
 }
 

--- a/pkg/connector/users_guard_test.go
+++ b/pkg/connector/users_guard_test.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+func hasAnno(rt *v2.ResourceType, msg proto.Message) bool {
+	for _, a := range rt.GetAnnotations() {
+		if a.MessageIs(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// The user type's only grants are cross-type role grants, so when role is
+// excluded the whole grants pass is skipped.
+func TestUserResourceType_SkipAnnotation(t *testing.T) {
+	inScope := newUserBuilder(nil, false).ResourceType(context.Background())
+	if !hasAnno(inScope, &v2.SkipEntitlements{}) || hasAnno(inScope, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("role in scope: want SkipEntitlements only, got %v", inScope.Annotations)
+	}
+
+	filtered := newUserBuilder(nil, true).ResourceType(context.Background())
+	if !hasAnno(filtered, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("role filtered: want SkipEntitlementsAndGrants, got %v", filtered.Annotations)
+	}
+
+	if hasAnno(userResourceType, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatal("package-level userResourceType was mutated")
+	}
+}
+
+// main.go registers a zero-value Connector{} as the capabilities factory, which
+// bypasses New; it must report the unfiltered capability set.
+func TestZeroValueConnector_DoesNotSkipGrants(t *testing.T) {
+	for _, s := range (&Connector{}).ResourceSyncers(context.Background()) {
+		rt := s.ResourceType(context.Background())
+		if rt.GetId() != userResourceType.Id {
+			continue
+		}
+		if hasAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+			t.Fatal("zero-value Connector advertised SkipEntitlementsAndGrants")
+		}
+	}
+}


### PR DESCRIPTION
Gates cross-type grant emission from the user syncer on the customer's sync
filter, so grants aren't emitted for a resource type the sync excludes.
Reference: ConductorOne/baton-linear#55.

Each target is guarded individually in Grants(); when every target is excluded
the user resource type is annotated SkipEntitlementsAndGrants so the SDK skips
the pass entirely.

Flags are named skip<Type>ResourceType and stored inverted so the zero value
means "sync everything" — main.go registers a zero-value Connector{} as the
capabilities factory, bypassing New.

Build, tests, and golangci-lint (0 issues) pass.
